### PR TITLE
Fixed crash on currupt layout file

### DIFF
--- a/thomas/ThomasEditor/MainWindow.xaml.cs
+++ b/thomas/ThomasEditor/MainWindow.xaml.cs
@@ -123,18 +123,25 @@ namespace ThomasEditor
 
         private void LoadLayout()
         {
-            string target = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "thomas/layout.dock");
-            if (System.IO.File.Exists(target))
+            try
             {
-                using (var sr = new StreamReader(target))
+                string target = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "thomas/layout.dock");
+                if (System.IO.File.Exists(target))
                 {
-                    using (StringWriter fs = new StringWriter())
+                    using (var sr = new StreamReader(target))
                     {
-                        XmlLayoutSerializer xmlLayout = new XmlLayoutSerializer(dockManager);
-                        xmlLayout.Deserialize(sr);
+                        using (StringWriter fs = new StringWriter())
+                        {
+                            XmlLayoutSerializer xmlLayout = new XmlLayoutSerializer(dockManager);
+                            xmlLayout.Deserialize(sr);
+                        }
                     }
                 }
+            }catch(Exception e)
+            {
+                Debug.Log("Failed to load editor layout. Error: " + e.Message);
             }
+
             this.Top = Properties.Settings.Default.Top;
             this.Left = Properties.Settings.Default.Left;
             this.Height = Properties.Settings.Default.Height;


### PR DESCRIPTION
Fixed crash when layout.dock (AppData\Local\thomas\layout.dock) file was currupt.