### PR TITLE
Game window is now focused when "play" is pressed

### DIFF
--- a/thomas/ThomasCore/src/thomas/Input.cpp
+++ b/thomas/ThomasCore/src/thomas/Input.cpp
@@ -1,7 +1,7 @@
 #include "Input.h"
 #include "ThomasTime.h"
 #include "Common.h"
-
+#include "Window.h"
 namespace thomas
 {
 	//Keyboard
@@ -25,6 +25,8 @@ namespace thomas
 	bool Input::s_initialized = false;
 	float Input::s_vibrateTimeLeft = 0.f;
 
+	bool Input::allowEditor = false;
+
 	bool Input::Init()
 	{
 		//Init objects
@@ -42,6 +44,7 @@ namespace thomas
 	{
 		if (s_initialized)
 		{
+			allowEditor = false;
 			s_keyboardState = s_keyboard->GetState();
 			s_gamePadState = s_gamePad->GetState(0);	
 			s_mouseState = s_mouse->GetState();
@@ -134,6 +137,8 @@ namespace thomas
 
 	void Input::SetMouseMode(MouseMode mode)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return;
 		if (s_mouseMode == mode)
 			return;
 
@@ -143,6 +148,8 @@ namespace thomas
 
 	math::Vector2 Input::GetMousePosition()
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return math::Vector2(0.f, 0.f);
 		if (s_recordPosition)
 			return s_mousePosition;
 		else
@@ -151,16 +158,22 @@ namespace thomas
 
 	float Input::GetMouseX()
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return 0;
 		return GetMousePosition().x;
 	}
 
 	float Input::GetMouseY()
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return 0;
 		return GetMousePosition().y;
 	}
 
 	bool Input::GetMouseButtonDown(MouseButtons button)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		switch (button)
 		{
 		case MouseButtons::LEFT:
@@ -175,6 +188,8 @@ namespace thomas
 
 	bool Input::GetMouseButtonUp(MouseButtons button)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		switch (button)
 		{
 		case MouseButtons::LEFT:
@@ -189,6 +204,8 @@ namespace thomas
 
 	bool Input::GetMouseButton(MouseButtons button)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		switch (button)
 		{
 		case MouseButtons::LEFT:
@@ -209,6 +226,8 @@ namespace thomas
 	//Gamepad
 	bool Input::GetButtonDown(Buttons button)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		if (!s_gamePadState.IsConnected()) //Always false if no gamePad.
 			return false;
 
@@ -252,6 +271,8 @@ namespace thomas
 
 	bool Input::GetButtonUp(Buttons button)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		if (!s_gamePadState.IsConnected()) //Always false if no gamePad.
 			return false;
 
@@ -295,6 +316,8 @@ namespace thomas
 
 	bool Input::GetButton(Buttons button)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		if (!s_gamePadState.IsConnected()) //Always false if no gamePad.
 			return false;
 
@@ -349,16 +372,22 @@ namespace thomas
 	//Keyboard
 	bool Input::GetKeyDown(Keys key)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		return s_keyboardTracker.IsKeyPressed((Keyboard::Keys)key);
 	}	
 
 	bool Input::GetKeyUp(Keys key)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		return s_keyboardTracker.IsKeyReleased((Keyboard::Keys)key);
 	}
 
 	bool Input::GetKey(Keys key)
 	{
+		if (Window::GetEditorWindow() && Window::GetEditorWindow()->IsFocused() && !allowEditor)
+			return false;
 		return s_keyboardState.IsKeyDown((Keyboard::Keys)key);
 	}
 }

--- a/thomas/ThomasCore/src/thomas/Input.h
+++ b/thomas/ThomasCore/src/thomas/Input.h
@@ -16,6 +16,7 @@ namespace thomas
 	class Input
 	{
 	public:
+		static bool allowEditor;
 		enum class MouseButtons
 		{
 			LEFT,

--- a/thomas/ThomasCore/src/thomas/editor/EditorCamera.cpp
+++ b/thomas/ThomasCore/src/thomas/editor/EditorCamera.cpp
@@ -169,6 +169,8 @@ namespace thomas
 			if (!Window::GetEditorWindow() || !Window::GetEditorWindow()->IsFocused())
 				return;
 
+			Input::allowEditor = true;
+
 			// Toggle editor mode on scene camera
 			if (Input::GetMouseButtonDown(Input::MouseButtons::RIGHT))
 				Input::SetMouseMode(Input::MouseMode::POSITION_RELATIVE);

--- a/thomas/ThomasEditor/utils/ThomasWindow.cs
+++ b/thomas/ThomasEditor/utils/ThomasWindow.cs
@@ -164,8 +164,14 @@ namespace ThomasEditor
 
 
             ThomasWrapper.CreateThomasWindow(Handle, IsEditor);
-
+            GotFocus += ThomasWindow_GotFocus;
             return new HandleRef(this, Handle);
+            
+        }
+
+        private void ThomasWindow_GotFocus(object sender, RoutedEventArgs e)
+        {
+            SetFocus(Handle);
         }
 
         protected override void DestroyWindowCore(HandleRef handle)


### PR DESCRIPTION
To test: Add "ChadControls" to a gameObject. When the play button is pressed you should now be able to control the character with WASD without needing to select the "game" window. If another window(like editor) is selected, pressing WASD should not move the character.