### PR TITLE
Fixed crash when saving layout if no "thomas" folder exists in AppDat…

### DIFF
--- a/thomas/ThomasEditor/MainWindow.xaml.cs
+++ b/thomas/ThomasEditor/MainWindow.xaml.cs
@@ -89,16 +89,24 @@ namespace ThomasEditor
 
         private void SaveLayout()
         {
-            string target = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "thomas/layout.dock");
-            using (var sw = new StreamWriter(target))
+            try
             {
-                using (StringWriter fs = new StringWriter())
+                Directory.CreateDirectory(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "thomas"));
+                string target = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "thomas/layout.dock");
+                using (var sw = new StreamWriter(target))
                 {
-                    XmlLayoutSerializer xmlLayout = new XmlLayoutSerializer(dockManager);
-                    xmlLayout.Serialize(fs);
-                    sw.Write(fs.ToString());
+                    using (StringWriter fs = new StringWriter())
+                    {
+                        XmlLayoutSerializer xmlLayout = new XmlLayoutSerializer(dockManager);
+                        xmlLayout.Serialize(fs);
+                        sw.Write(fs.ToString());
+                    }
                 }
+            }catch(Exception e)
+            {
+                Debug.Log("Failed to save layout.dock. Error: " + e.Message);
             }
+
 
             if (WindowState == WindowState.Maximized)
             {


### PR DESCRIPTION
Fixed crash that happend when the appData/thomas folder didnt exist and the file->Save layout button was pressed.

The fix: Create the folder if it does not exists (Added a try/catch block aswell)