### PR TITLE
Physics callbacks & triggers

### DIFF
--- a/Concussion Ball/Assets/Ball.cs
+++ b/Concussion Ball/Assets/Ball.cs
@@ -38,11 +38,11 @@ public class Ball : ScriptComponent
     }
 
 
-    public override void OnCollisionEnter(GameObject collider)
+    public override void OnCollisionEnter(Collider collider)
     {
         if (rb.enabled)
         {
-            playerThatHasBall = collider;
+            playerThatHasBall = collider.gameObject;
             rb.enabled = false;
             transform.parent = collider.transform;
             transform.localPosition = new Vector3(0, 2, 0);

--- a/Concussion Ball/Assets/StandardSkinning.mat
+++ b/Concussion Ball/Assets/StandardSkinning.mat
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Material xmlns:i="http://www.w3.org/2001/XMLSchema-instance" z:Id="1" xmlns:z="http://schemas.microsoft.com/2003/10/Serialization/" xmlns="http://schemas.datacontract.org/2004/07/ThomasEngine">
-  <asset_path z:Id="2">StandardShader Material.mat</asset_path>
+  <asset_path z:Id="2">%THOMAS_ASSETS%\StandardSkinning.mat</asset_path>
   <Shader z:Id="3">
     <asset_path z:Id="4">%THOMAS_DATA%\FXIncludes\StandardSkinning.fx</asset_path>
   </Shader>

--- a/Concussion Ball/Assets/collisionTest.cs
+++ b/Concussion Ball/Assets/collisionTest.cs
@@ -1,0 +1,25 @@
+using ThomasEngine;
+
+public class CollisionTest : ScriptComponent
+{
+    public override void Start()
+    {
+        
+    }
+
+    public override void Update()
+    {
+        
+    }
+
+    public override void OnCollisionEnter(Collider collider)
+    {
+        Debug.Log("enter!");
+    }
+    public override void OnCollisionExit(Collider collider)
+    {
+        Debug.Log("exit!");
+    }
+
+
+}

--- a/Concussion Ball/Concussion Ball.csproj
+++ b/Concussion Ball/Concussion Ball.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assets\Ball.cs" />
+    <Compile Include="Assets\collisionTest.cs" />
     <Compile Include="Assets\Scripts\chadControls.cs" />
     <Compile Include="Assets\throwStrengthVisualizer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Concussion Ball/Concussion Ball.thomas
+++ b/Concussion Ball/Concussion Ball.thomas
@@ -2,6 +2,6 @@
 <Project xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.datacontract.org/2004/07/ThomasEngine">
   <m_name>Concussion Ball</m_name>
   <m_relativeAssemblyPath>Assembly</m_relativeAssemblyPath>
-  <m_relativeCurrentScenePath>Scene.tds</m_relativeCurrentScenePath>
+  <m_relativeCurrentScenePath>scene.tds</m_relativeCurrentScenePath>
   <m_relativeResourcePath>Assets</m_relativeResourcePath>
 </Project>

--- a/thomas/ThomasCore/src/thomas/Physics.cpp
+++ b/thomas/ThomasCore/src/thomas/Physics.cpp
@@ -77,31 +77,6 @@ namespace thomas
 
 		s_world->stepSimulation(s_timeSinceLastPhysicsStep, 5, s_timeStep);
 
-		// Solve collision between two rigidbodies
-		//int numManifolds = s_world->getDispatcher()->getNumManifolds();
-
-		//for (unsigned i = 0; i < numManifolds; ++i)
-		//{
-		//	if (numManifolds > s_world->getDispatcher()->getNumManifolds())
-		//		break;
-		//		
-		//	btPersistentManifold* contactManifold = s_world->getDispatcher()->getManifoldByIndexInternal(i);
-		//	btCollisionObject* obA = (btCollisionObject*)contactManifold->getBody0();
-		//	btCollisionObject* obB = (btCollisionObject*)contactManifold->getBody1();
-
-		//	// Avoid self collisions
-		//	if (obA == obB) continue;
-
-		//	if (obA->getUserPointer() && obB->getUserPointer())
-		//	{
-		//		object::component::Collider* colliderA = static_cast<object::component::Collider*>(obA->getUserPointer());
-		//		object::component::Collider* colliderB = static_cast<object::component::Collider*>(obB->getUserPointer());
-
-		//		colliderA->OnCollision(colliderB);
-		//		colliderB->OnCollision(colliderA);
-		//	}
-		//}
-
 		for (object::component::Rigidbody* rb : s_rigidBodies)
 		{
 			rb->UpdateRigidbodyToTransform();

--- a/thomas/ThomasCore/src/thomas/Physics.h
+++ b/thomas/ThomasCore/src/thomas/Physics.h
@@ -11,6 +11,12 @@ namespace thomas
 	class Physics
 	{
 	public:
+		enum class COLLISION_TYPE {
+			STARTED,
+			STAY,
+			ENDED
+		};
+	public:
 		static bool Init();
 		static void AddRigidBody(object::component::Rigidbody* rigidBody);
 		static bool RemoveRigidBody(object::component::Rigidbody* rigidBody);
@@ -18,7 +24,11 @@ namespace thomas
 		static void Simulate();
 		static void DrawDebug(object::component::Camera* camera);
 		static void Destroy();
-
+	private:
+		static void CollisionStarted(btPersistentManifold* const& manifold);
+		static bool CollisionProcessed(btManifoldPoint& cp, void* body0, void* body1);
+		static void CollisionEnded(btPersistentManifold* const& manifold);
+		static void HandleCollision(const btCollisionObject* body0, const btCollisionObject* body1, COLLISION_TYPE collisionType);
 	public:
 		static graphics::BulletDebugDraw* getDebugDraw();
 

--- a/thomas/ThomasCore/src/thomas/object/component/Component.h
+++ b/thomas/ThomasCore/src/thomas/object/component/Component.h
@@ -18,7 +18,6 @@ namespace thomas
 				virtual void FixedUpdate() {};
 				virtual void OnDrawGizmos() {};
 				virtual void OnDrawGizmosSelected() {};
-				virtual void OnCollisionEnter(GameObject* collider) {};
 
 			public:
 				bool initialized = false;

--- a/thomas/ThomasCore/src/thomas/object/component/physics/Collider.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/Collider.cpp
@@ -44,6 +44,23 @@ namespace thomas
 
 			void Collider::SetTrigger(bool trigger)
 			{
+				if (trigger) {
+					if (m_attachedRigidbody) {
+						m_attachedRigidbody->setCollisionFlags(m_attachedRigidbody->getCollisionFlags() | Rigidbody::CF_NO_CONTACT_RESPONSE);
+					}
+					else if (m_collisionObject) {
+						m_collisionObject->setCollisionFlags(m_collisionObject->getCollisionFlags() | Rigidbody::CF_NO_CONTACT_RESPONSE);
+					}
+				}
+				else
+				{
+					if (m_attachedRigidbody) {
+						m_attachedRigidbody->setCollisionFlags(m_attachedRigidbody->getCollisionFlags() & ~Rigidbody::CF_NO_CONTACT_RESPONSE);
+					}
+					else if (m_collisionObject) {
+						m_collisionObject->setCollisionFlags(m_collisionObject->getCollisionFlags() & ~Rigidbody::CF_NO_CONTACT_RESPONSE);
+					}
+				}
 				m_trigger = trigger;
 			}
 
@@ -69,6 +86,7 @@ namespace thomas
 					m_collisionObject = new btCollisionObject();
 					m_collisionObject->setCollisionShape(m_collisionShape);
 					m_collisionObject->setUserPointer(this);
+					SetTrigger(m_trigger); //Update trigger flags
 					Physics::s_world->addCollisionObject(m_collisionObject);
 				}
 			}

--- a/thomas/ThomasCore/src/thomas/object/component/physics/Collider.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/Collider.cpp
@@ -47,6 +47,17 @@ namespace thomas
 				m_trigger = trigger;
 			}
 
+			void Collider::SetOnCollisionEvent(OnCollisionEvent value)
+			{
+				m_onCollisionEvent = value;
+			}
+
+			void Collider::OnCollision(Collider * otherCollider, Physics::COLLISION_TYPE collisionType)
+			{
+				if (m_onCollisionEvent)
+					m_onCollisionEvent(otherCollider, collisionType);
+			}
+
 			void Collider::Awake()
 			{
 			}
@@ -57,6 +68,7 @@ namespace thomas
 				{
 					m_collisionObject = new btCollisionObject();
 					m_collisionObject->setCollisionShape(m_collisionShape);
+					m_collisionObject->setUserPointer(this);
 					Physics::s_world->addCollisionObject(m_collisionObject);
 				}
 			}

--- a/thomas/ThomasCore/src/thomas/object/component/physics/Collider.h
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/Collider.h
@@ -12,6 +12,8 @@ namespace thomas
 			class Collider : public Component
 			{
 			public:
+				typedef void(*OnCollisionEvent)(Collider* otherCollider, Physics::COLLISION_TYPE collisionType);
+			public:
 				Collider(btCollisionShape* collisionShape);
 				~Collider();
 				
@@ -22,7 +24,8 @@ namespace thomas
 				void SetAttachedRigidbody(Rigidbody* rb);
 				bool IsTrigger();
 				void SetTrigger(bool trigger);
-
+				void SetOnCollisionEvent(OnCollisionEvent value);
+				void OnCollision(Collider* otherCollider, Physics::COLLISION_TYPE collisionType);
 				void Awake();
 				void OnEnable();
 				void OnDisable();
@@ -38,6 +41,7 @@ namespace thomas
 				btCollisionShape* m_collisionShape = nullptr;
 				btCollisionObject* m_collisionObject = nullptr;
 				Rigidbody* m_attachedRigidbody = nullptr;
+				OnCollisionEvent m_onCollisionEvent = NULL;
 			};
 		}
 	}

--- a/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.cpp
@@ -13,13 +13,12 @@ namespace thomas
 		{
 			Rigidbody::Rigidbody() : 
 			btRigidBody(1, NULL, NULL), 
-			m_targetCollider(nullptr), m_hasGravity(true), 
+			m_hasGravity(true), 
 			m_kinematic(false), 
 			m_mass(1.f),
 			m_freezePosition(1.f),
 			m_freezeRotation(1.f)
 			{
-				this->setUserPointer(this);
 				Physics::RemoveRigidBody(this);
 				btDefaultMotionState* motionState = new btDefaultMotionState();
 				setMotionState(motionState);
@@ -136,6 +135,7 @@ namespace thomas
 				bool removed = Physics::RemoveRigidBody(this);
 				delete getCollisionShape();
 				setCollisionShape(collider->GetCollisionShape());
+				this->setUserPointer(collider);
 				UpdateRigidbodyMass();
 				if(removed)
 					Physics::AddRigidBody(this);
@@ -152,17 +152,7 @@ namespace thomas
 				}
 			}
 
-			void Rigidbody::SetTargetCollider(GameObject* collider)
-			{
-				if (m_targetCollider == nullptr)
-				{
-					m_targetCollider = std::make_unique<GameObject>("");					
-				}
-
-				// Don't change the pointer if target collider has not been updated
-				if(m_targetCollider.get() != collider)
-					*m_targetCollider = *collider;
-			}
+			
 
 			void Rigidbody::AddTorque(const math::Vector3 & torque, ForceMode mode)
 			{
@@ -187,23 +177,7 @@ namespace thomas
 				else if (mode == ForceMode::Impulse)
 					this->applyImpulse(Physics::ToBullet(force), Physics::ToBullet(relPos));
 			}
-
-			GameObject * Rigidbody::GetTargetCollider()
-			{
-				if (m_targetCollider != nullptr)
-				{
-					if (this->hasContactResponse() && m_targetCollider->GetComponent<object::component::Rigidbody>()->hasContactResponse())
-						return m_targetCollider.get();
-				}
-
-				return nullptr;
-			}
-
-			void Rigidbody::ClearTargetCollider()
-			{
-				m_targetCollider.reset();
-			}
-
+						
 			float Rigidbody::GetMass() const
 			{
 				return m_mass;

--- a/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.cpp
@@ -136,6 +136,8 @@ namespace thomas
 				delete getCollisionShape();
 				setCollisionShape(collider->GetCollisionShape());
 				this->setUserPointer(collider);
+				collider->SetAttachedRigidbody(this);
+				collider->SetTrigger(collider->IsTrigger());
 				UpdateRigidbodyMass();
 				if(removed)
 					Physics::AddRigidBody(this);

--- a/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.cpp
@@ -83,6 +83,8 @@ namespace thomas
 					trans.setOrigin((btVector3&)pos);
 					trans.setRotation((btQuaternion&)rot);
 					getMotionState()->setWorldTransform(trans);
+					this->setLinearVelocity(btVector3(0, 0, 0));
+					this->setAngularVelocity(btVector3(0, 0, 0));
 					setCenterOfMassTransform(trans);
 					Physics::s_world->updateSingleAabb(this);
 					activate();

--- a/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.h
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/Rigidbody.h
@@ -38,16 +38,13 @@ namespace thomas
 				void SetKinematic(bool kinematic);
 				void SetCollider(Collider* collider);
 				void SetMass(float mass);
-				void SetTargetCollider(GameObject* collider);
 
 			public:
-				GameObject* GetTargetCollider();
 				float GetMass() const;
 				bool HasGravity() const;
 				bool IsKinematic() const;
 				math::Vector3 GetFreezePosition() const;
 				math::Vector3 GetFreezeRotation() const;
-				void ClearTargetCollider();
 
 			private:
 				void UpdateRigidbodyMass();
@@ -60,7 +57,6 @@ namespace thomas
 				float m_mass;
 				bool m_kinematic;
 				bool m_hasGravity;
-				std::unique_ptr<GameObject> m_targetCollider; // Temp
 			};
 		}
 	}

--- a/thomas/ThomasEngine/src/ThomasManaged.cpp
+++ b/thomas/ThomasEngine/src/ThomasManaged.cpp
@@ -118,12 +118,6 @@ namespace ThomasEngine {
 				GameObject^ gameObject = Scene::CurrentScene->GameObjects[i];
 				if (gameObject->GetActive())
 				{
-					auto collider = gameObject->GetComponent<Rigidbody^>()->GetTargetCollider();
-					if (collider != nullptr)
-					{
-						gameObject->OnCollisionEnter(collider);
-					}
-
 					gameObject->Update();
 				}
 			}

--- a/thomas/ThomasEngine/src/object/Component.cpp
+++ b/thomas/ThomasEngine/src/object/Component.cpp
@@ -88,10 +88,6 @@ namespace ThomasEngine
 		((thomas::object::GameObject*)m_gameObject->nativePtr)->m_components.push_back(((thomas::object::component::Component*)nativePtr));
 	}
 
-	void Component::OnCollisionEnter(GameObject ^ collider)
-	{
-		((thomas::object::component::Component*)nativePtr)->OnCollisionEnter((thomas::object::GameObject*)collider->nativePtr);
-	}
 
 	void Component::Destroy()
 	{

--- a/thomas/ThomasEngine/src/object/Component.h
+++ b/thomas/ThomasEngine/src/object/Component.h
@@ -8,6 +8,7 @@ namespace thomas { namespace object { namespace component { class Component; } }
 namespace ThomasEngine 
 {
 	ref class GameObject;
+	ref class Collider;
 	ref class Transform;
 	[HideInInspector]
 	[SerializableAttribute]
@@ -36,7 +37,14 @@ namespace ThomasEngine
 		virtual void FixedUpdate();
 		virtual void OnDrawGizmosSelected();
 		virtual void OnDrawGizmos();
-		virtual void OnCollisionEnter(GameObject^ collider);
+
+		virtual void OnCollisionEnter(Collider^ collider) {};
+		virtual void OnCollisionStay(Collider^ collider) {};
+		virtual void OnCollisionExit(Collider^ collider) {};
+
+		virtual void OnTriggerEnter(Collider^ collider) {};
+		virtual void OnTriggerStay(Collider^ collider) {};
+		virtual void OnTriggerExit(Collider^ collider) {};
 
 		GameObject^ m_gameObject;
 

--- a/thomas/ThomasEngine/src/object/GameObject.cpp
+++ b/thomas/ThomasEngine/src/object/GameObject.cpp
@@ -109,18 +109,6 @@ namespace ThomasEngine {
 		Monitor::Exit(m_componentsLock);
 	}
 
-	void GameObject::OnCollisionEnter(GameObject^ collider)
-	{
-		Monitor::Enter(m_componentsLock);
-
-		for (int i = 0; i < m_components.Count; i++)
-		{
-			Component^ component = m_components[i];
-			if (component->enabled)
-				component->OnCollisionEnter(collider);
-		}
-		Monitor::Exit(m_componentsLock);
-	}
 
 	void GameObject::RenderGizmos()
 	{

--- a/thomas/ThomasEngine/src/object/GameObject.h
+++ b/thomas/ThomasEngine/src/object/GameObject.h
@@ -50,7 +50,6 @@ namespace ThomasEngine
 		void RenderGizmos();
 
 		void RenderSelectedGizmos();
-		void OnCollisionEnter(GameObject^ collider);
 		
 	public:
 

--- a/thomas/ThomasEngine/src/object/component/ScriptComponent.h
+++ b/thomas/ThomasEngine/src/object/component/ScriptComponent.h
@@ -18,7 +18,14 @@ namespace ThomasEngine
 		virtual void Update()override {};
 		virtual void OnDrawGizmosSelected() override {};
 		virtual void OnDrawGizmos() override {};
-		virtual void OnCollisionEnter(GameObject^ collider) override {};
+
+		virtual void OnCollisionEnter(Collider^ collider) override {};
+		virtual void OnCollisionStay(Collider^ collider) override {};
+		virtual void OnCollisionExit(Collider^ collider) override {};
+
+		virtual void OnTriggerEnter(Collider^ collider) override {};
+		virtual void OnTriggerStay(Collider^ collider) override {};
+		virtual void OnTriggerExit(Collider^ collider) override {};
 
 	};
 }

--- a/thomas/ThomasEngine/src/object/component/physics/CapsuleCollider.h
+++ b/thomas/ThomasEngine/src/object/component/physics/CapsuleCollider.h
@@ -3,6 +3,7 @@
 #include <thomas\object\component\physics\CapsuleCollider.h>
 #pragma managed
 #include "Collider.h"
+#include "../../../Utility.h"
 namespace ThomasEngine
 {
 	public ref class CapsuleCollider : public Collider

--- a/thomas/ThomasEngine/src/object/component/physics/Collider.cpp
+++ b/thomas/ThomasEngine/src/object/component/physics/Collider.cpp
@@ -1,14 +1,68 @@
+#pragma unmanaged
+#include <thomas\object\component\physics\Collider.h>
+#pragma managed
 #include "Collider.h"
 #include "Rigidbody.h"
-void ThomasEngine::Collider::attachedRigidbody::set(Rigidbody^ value)
+#include "../../GameObject.h"
+
+namespace ThomasEngine
 {
-	m_attachedRigidbody = value;
-	if (m_attachedRigidbody)
+
+	Collider::Collider(component::Collider * nativePtr) : Component(nativePtr)
 	{
-		((thomas::object::component::Collider*)nativePtr)->SetAttachedRigidbody((thomas::object::component::Rigidbody*)value->nativePtr);
+		OnCollisionDelegate^ fp = gcnew OnCollisionDelegate(this, &Collider::OnCollision);
+		gch = GCHandle::Alloc(fp);
+		IntPtr ip = Marshal::GetFunctionPointerForDelegate(fp);
+		component::Collider::OnCollisionEvent cb = static_cast<component::Collider::OnCollisionEvent>(ip.ToPointer());
+		nativePtr->SetOnCollisionEvent(cb);
 	}
-	else
+	Collider::~Collider() 
 	{
-		((thomas::object::component::Collider*)nativePtr)->SetAttachedRigidbody(nullptr);
+		gch.Free();
 	}
+
+	void Collider::OnCollision(component::Collider* otherCollider, COLLISION_TYPE collisionType)
+	{
+		Collider^ collider = (Collider^)Object::Find(Utility::Convert(otherCollider->m_guid));
+		switch (collisionType)
+		{
+		case COLLISION_TYPE::STARTED:
+			for (int i = 0; i < gameObject->Components->Count; i++)
+			{
+				gameObject->Components[i]->OnCollisionEnter(collider);
+			}
+			break;
+		case COLLISION_TYPE::STAY:
+			for (int i = 0; i < gameObject->Components->Count; i++)
+			{
+				gameObject->Components[i]->OnCollisionStay(collider);
+			}
+			break;
+		case COLLISION_TYPE::ENDED:
+			for (int i = 0; i < gameObject->Components->Count; i++)
+			{
+				gameObject->Components[i]->OnCollisionExit(collider);
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	void Collider::attachedRigidbody::set(Rigidbody^ value)
+	{
+		m_attachedRigidbody = value;
+		if (m_attachedRigidbody)
+		{
+			((component::Collider*)nativePtr)->SetAttachedRigidbody((component::Rigidbody*)value->nativePtr);
+		}
+		else
+		{
+			((component::Collider*)nativePtr)->SetAttachedRigidbody(nullptr);
+		}
+	}
+
+	bool Collider::isTrigger::get() { return ((component::Collider*)nativePtr)->IsTrigger(); }
+	void Collider::isTrigger::set(bool value) { ((component::Collider*)nativePtr)->SetTrigger(value); }
 }
+

--- a/thomas/ThomasEngine/src/object/component/physics/Collider.cpp
+++ b/thomas/ThomasEngine/src/object/component/physics/Collider.cpp
@@ -24,29 +24,59 @@ namespace ThomasEngine
 	void Collider::OnCollision(component::Collider* otherCollider, COLLISION_TYPE collisionType)
 	{
 		Collider^ collider = (Collider^)Object::Find(Utility::Convert(otherCollider->m_guid));
-		switch (collisionType)
+		if (collider->isTrigger || isTrigger) //If one of the colliders is a trigger we do OnColliderX instead.
 		{
-		case COLLISION_TYPE::STARTED:
-			for (int i = 0; i < gameObject->Components->Count; i++)
+			switch (collisionType)
 			{
-				gameObject->Components[i]->OnCollisionEnter(collider);
+			case COLLISION_TYPE::STARTED:
+				for (int i = 0; i < gameObject->Components->Count; i++)
+				{
+					gameObject->Components[i]->OnTriggerEnter(collider);
+				}
+				break;
+			case COLLISION_TYPE::STAY:
+				for (int i = 0; i < gameObject->Components->Count; i++)
+				{
+					gameObject->Components[i]->OnTriggerStay(collider);
+				}
+				break;
+			case COLLISION_TYPE::ENDED:
+				for (int i = 0; i < gameObject->Components->Count; i++)
+				{
+					gameObject->Components[i]->OnTriggerExit(collider);
+				}
+				break;
+			default:
+				break;
 			}
-			break;
-		case COLLISION_TYPE::STAY:
-			for (int i = 0; i < gameObject->Components->Count; i++)
-			{
-				gameObject->Components[i]->OnCollisionStay(collider);
-			}
-			break;
-		case COLLISION_TYPE::ENDED:
-			for (int i = 0; i < gameObject->Components->Count; i++)
-			{
-				gameObject->Components[i]->OnCollisionExit(collider);
-			}
-			break;
-		default:
-			break;
 		}
+		else
+		{
+			switch (collisionType)
+			{
+			case COLLISION_TYPE::STARTED:
+				for (int i = 0; i < gameObject->Components->Count; i++)
+				{
+					gameObject->Components[i]->OnCollisionEnter(collider);
+				}
+				break;
+			case COLLISION_TYPE::STAY:
+				for (int i = 0; i < gameObject->Components->Count; i++)
+				{
+					gameObject->Components[i]->OnCollisionStay(collider);
+				}
+				break;
+			case COLLISION_TYPE::ENDED:
+				for (int i = 0; i < gameObject->Components->Count; i++)
+				{
+					gameObject->Components[i]->OnCollisionExit(collider);
+				}
+				break;
+			default:
+				break;
+			}
+		}
+		
 	}
 
 	void Collider::attachedRigidbody::set(Rigidbody^ value)

--- a/thomas/ThomasEngine/src/object/component/physics/Collider.h
+++ b/thomas/ThomasEngine/src/object/component/physics/Collider.h
@@ -1,9 +1,7 @@
 #pragma once
-#pragma unmanaged
-#include <thomas\object\component\physics\Collider.h>
-#pragma managed
 #include "../../Component.h"
-#include "Rigidbody.h"
+using namespace System::Runtime::InteropServices;
+using namespace thomas::object;
 namespace ThomasEngine
 {
 	ref class Rigidbody;
@@ -13,11 +11,22 @@ namespace ThomasEngine
 	{
 	internal:
 		Collider() : Component(nullptr){}
+		enum class COLLISION_TYPE
+		{
+			STARTED,
+			STAY,
+			ENDED
+		};
 	private:
 		Rigidbody^ m_attachedRigidbody;
+		delegate void OnCollisionDelegate(component::Collider* otherCollider, COLLISION_TYPE collisionType);
+		GCHandle gch;
+		void OnCollision(component::Collider* otherCollider, COLLISION_TYPE collisionType);
 	public:
-		Collider(thomas::object::component::Collider* nativePtr) : Component(nativePtr) {}
+		Collider(component::Collider* nativePtr);
+		~Collider();
 		
+
 		[BrowsableAttribute(false)]
 		property Rigidbody^ attachedRigidbody {
 			Rigidbody^ get() { return m_attachedRigidbody; }
@@ -25,10 +34,11 @@ namespace ThomasEngine
 			
 		}
 
+
 		property bool isTrigger
 		{
-			bool get() { return ((thomas::object::component::Collider*)nativePtr)->IsTrigger(); }
-			void set(bool value) { ((thomas::object::component::Collider*)nativePtr)->SetTrigger(value); }
+			bool get();
+			void set(bool value);
 		}
 	};
 }

--- a/thomas/ThomasEngine/src/object/component/physics/MeshCollider.cpp
+++ b/thomas/ThomasEngine/src/object/component/physics/MeshCollider.cpp
@@ -6,10 +6,23 @@
 #include "MeshCollider.h"
 #include "../../../resource/Model.h"
 #include "../../../resource/Resources.h"
-
+#include "../../GameObject.h"
+#include "../RenderComponent.h"
 namespace ThomasEngine
 {
-	MeshCollider::MeshCollider() : Collider(new thomas::object::component::MeshCollider()) {}
+	MeshCollider::MeshCollider() : Collider(new thomas::object::component::MeshCollider()) {
+		
+	}
+
+	void MeshCollider::Start()
+	{
+		if (gameObject) 
+		{
+			RenderComponent^ renderComp = gameObject->GetComponent<RenderComponent^>();
+			if (renderComp && renderComp->model)
+				mesh = renderComp->model;
+		}
+	}
 
 	Model^ MeshCollider::mesh::get() 
 	{

--- a/thomas/ThomasEngine/src/object/component/physics/MeshCollider.cpp
+++ b/thomas/ThomasEngine/src/object/component/physics/MeshCollider.cpp
@@ -16,7 +16,7 @@ namespace ThomasEngine
 
 	void MeshCollider::Start()
 	{
-		if (gameObject) 
+		if (!mesh && gameObject) 
 		{
 			RenderComponent^ renderComp = gameObject->GetComponent<RenderComponent^>();
 			if (renderComp && renderComp->model)

--- a/thomas/ThomasEngine/src/object/component/physics/MeshCollider.h
+++ b/thomas/ThomasEngine/src/object/component/physics/MeshCollider.h
@@ -5,17 +5,17 @@
 namespace ThomasEngine
 {
 	ref class Model;
+	[ExecuteInEditor]
 	public ref class MeshCollider : public Collider
 	{
 	internal:
 
 	public:
 		MeshCollider();
-
+		void Start() override;
 		property Model^ mesh
 		{
 			Model^ get();
-
 			void set(Model^ value);
 
 		}

--- a/thomas/ThomasEngine/src/object/component/physics/Rigidbody.cpp
+++ b/thomas/ThomasEngine/src/object/component/physics/Rigidbody.cpp
@@ -25,20 +25,3 @@ void ThomasEngine::Rigidbody::OnDestroy()
 	}
 	Component::OnDestroy();
 }
-
-ThomasEngine::GameObject^ ThomasEngine::Rigidbody::GetTargetCollider()
-{
-	if (this != nullptr)
-	{
-		auto collider = ((thomas::object::component::Rigidbody*)nativePtr)->GetTargetCollider();
-
-		if (collider != nullptr)
-		{
-			GameObject^ target = (GameObject^)Object::Find(Utility::Convert(collider->m_guid));
-			((thomas::object::component::Rigidbody*)nativePtr)->ClearTargetCollider();
-			return target;
-		}
-	}
-
-	return nullptr;
-}

--- a/thomas/ThomasEngine/src/object/component/physics/Rigidbody.h
+++ b/thomas/ThomasEngine/src/object/component/physics/Rigidbody.h
@@ -57,8 +57,6 @@ namespace ThomasEngine
 																(thomas::object::component::ForceMode)mode);
 		}
 
-		GameObject^ GetTargetCollider();
-
 		property bool IsKinematic 
 		{
 			bool get() { return ((thomas::object::component::Rigidbody*)nativePtr)->IsKinematic(); }


### PR DESCRIPTION
Improved the physics callbacks.
To use, override these functions in a component.
* OnCollisionEnter(Collider collider) - Calls once when a collision is started. collider is the other Collider that was present in this collision.

* OnCollisionStay(Collider collider) - Same as above, but will be called every frame the collision happens.
* OnCollsionExit(Collider collider) - Same as above, but will be called once when the collision exists.

If a collider is a trigger, OnTriggerEnter(Collider collider), OnTriggerStay(Collider collider) & OnTrigerExit(Collider collider) will be called instead.

Also made mesh colliders auto pick the mesh from a renderComponent if present on the gameObject at creation.