### PR TITLE
Workflow/master

### DIFF
--- a/thomas/ThomasEditor/Elements/AssetBrowser.xaml
+++ b/thomas/ThomasEditor/Elements/AssetBrowser.xaml
@@ -24,7 +24,7 @@
                             <Separator/>
                             <MenuItem Header="Material" Click="Menu_CreateMaterial"/>
                         </MenuItem>
-                        <MenuItem Header="Open" IsEnabled="{Binding}" Click="Menu_OpenAsset" />
+                        <MenuItem Header="Open" IsEnabled="{Binding Path=CheckSceneFile}" Click="Menu_OpenAsset" />
                         <MenuItem Header="Delete" IsEnabled="{Binding}"  Click="Menu_DeleteAsset"/>
                         <MenuItem Header="Rename" IsEnabled="{Binding}" Click="MenuItem_Rename"/>
                         <Separator/>

--- a/thomas/ThomasEditor/Elements/AssetBrowser.xaml
+++ b/thomas/ThomasEditor/Elements/AssetBrowser.xaml
@@ -24,7 +24,7 @@
                             <Separator/>
                             <MenuItem Header="Material" Click="Menu_CreateMaterial"/>
                         </MenuItem>
-                        <MenuItem Header="Open" IsEnabled="{Binding Path=CheckSceneFile}" Click="Menu_OpenAsset" />
+                        <MenuItem Header="Open" x:Name="contextMenuOpenItem" IsEnabled="{Binding}" Click="Menu_OpenAsset" />
                         <MenuItem Header="Delete" IsEnabled="{Binding}"  Click="Menu_DeleteAsset"/>
                         <MenuItem Header="Rename" IsEnabled="{Binding}" Click="MenuItem_Rename"/>
                         <Separator/>

--- a/thomas/ThomasEditor/Elements/AssetBrowser.xaml.cs
+++ b/thomas/ThomasEditor/Elements/AssetBrowser.xaml.cs
@@ -414,6 +414,20 @@ namespace ThomasEditor
             item.Focus();
         }
 
+        private bool CheckSceneFile()
+        {
+            TreeViewItem item = fileTree.SelectedItem as TreeViewItem;
+            StackPanel stack = item.Header as StackPanel;
+
+            String file = stack.DataContext as String;
+            ThomasEngine.Resources.AssetTypes assetType = ThomasEngine.Resources.GetResourceAssetType(file);
+            if (assetType == ThomasEngine.Resources.AssetTypes.SCENE)
+            {
+                return true;
+            }
+            return false;
+        }
+
         private void AssetBrowser_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
             TreeViewItem treeViewItem = VisualUpwardSearch(e.OriginalSource as DependencyObject);
@@ -427,6 +441,7 @@ namespace ThomasEditor
             else
             {
                 TreeViewItem item = fileTree.SelectedItem as TreeViewItem;
+                
                 if(item != null)
                     item.IsSelected = false;
                 assetBrowserContextMenu.DataContext = false;
@@ -459,10 +474,8 @@ namespace ThomasEditor
             if (fileTree.SelectedItem == null)
                 return;
             TreeViewItem item = fileTree.SelectedItem as TreeViewItem;
-            if (e.ClickCount == 2)
-            {
-                OpenItem(item);
-            }
+
+            OpenItem(item);
         }
 
         private void StartRename()

--- a/thomas/ThomasEditor/Elements/AssetBrowser.xaml.cs
+++ b/thomas/ThomasEditor/Elements/AssetBrowser.xaml.cs
@@ -414,6 +414,7 @@ namespace ThomasEditor
             item.Focus();
         }
 
+
         private bool CheckSceneFile()
         {
             TreeViewItem item = fileTree.SelectedItem as TreeViewItem;
@@ -435,7 +436,9 @@ namespace ThomasEditor
             if (treeViewItem != null)
             {
                 treeViewItem.Focus();
+                
                 assetBrowserContextMenu.DataContext = true;
+                contextMenuOpenItem.IsEnabled = CheckSceneFile();
                 //e.Handled = true;
             }
             else

--- a/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml
+++ b/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml
@@ -19,7 +19,24 @@
                         <CommandBinding Command="commands:CustomCommands.GetPasteObject" CanExecute="PasteObject_CanExecute" Executed="MenuItem_PasteGameObject"/>
                         <CommandBinding Command="commands:CustomCommands.GetDuplicateObject" CanExecute="CopyObject_CanExecute" Executed="MenuItem_DuplicateGameObject"/>
                     </ContextMenu.CommandBindings>
-                    
+                    <MenuItem Header="Create">
+                        <MenuItem Header="Empty Object" Click="AddEmptyGameObject"/>
+                        <MenuItem Header="3D Objects">
+                            <MenuItem Header="Cube" Click="AddNewCubePrimitive"/>
+                            <MenuItem Header="Sphere" Click="AddNewSpherePrimitive"/>
+                            <MenuItem Header="Capsule" Click="AddNewCapsulePrimitive"/>
+                            <MenuItem Header="Cylinder" Click="AddNewCylinderPrimitive"/>
+                            <MenuItem Header="Plane" Click="AddNewPlanePrimitive"/>
+                            <MenuItem Header="Quad" Click="AddNewQuadPrimitive"/>
+                        </MenuItem>
+                        <MenuItem Header="Assisting Objects">
+                            <MenuItem Header="Camera" Click="AddNewCameraPrimitive"/>
+                            <MenuItem Header="POINT Light" Click="AddNewPointLightPrimitive"/>
+                            <MenuItem Header="SPOT Light" Click="AddNewSpotLightPrimitive"/>
+                            <MenuItem Header="DIRECTIONAL Light" Click="AddNewDirectionalLightPrimitive"/>
+                            <MenuItem Header="AREA Light" Click="AddNewAreaLightPrimitive"/>
+                        </MenuItem>
+                    </MenuItem>
                     <MenuItem Header="Delete" Click="MenuItem_DeleteGameObject" IsEnabled="{Binding}"/>
                     <Separator/>
                     <MenuItem Command="{x:Static commands:CustomCommands.GetCopyObject}"/>

--- a/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml.cs
+++ b/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml.cs
@@ -520,5 +520,84 @@ namespace ThomasEditor
         {
             return hierarchy.SelectedItem as TreeViewItem;
         }
+
+        private void AddNewCubePrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddNewSpherePrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddNewQuadPrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddNewPlanePrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddNewCylinderPrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddNewCapsulePrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddNewCameraPrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = new GameObject("newCamera");
+            x.AddComponent<Camera>();
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddNewPointLightPrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = new GameObject("newPointLight");
+            x.AddComponent<LightComponent>();
+            x.GetComponent<LightComponent>().Type = LightComponent.LIGHT_TYPES.POINT;
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+        private void AddNewSpotLightPrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = new GameObject("newSpotLight");
+            x.AddComponent<LightComponent>();
+            x.GetComponent<LightComponent>().Type = LightComponent.LIGHT_TYPES.SPOT;
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+        private void AddNewDirectionalLightPrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = new GameObject("newDirectionalLight");
+            x.AddComponent<LightComponent>();
+            x.GetComponent<LightComponent>().Type = LightComponent.LIGHT_TYPES.DIRECTIONAL;
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+        private void AddNewAreaLightPrimitive(object sender, RoutedEventArgs e)
+        {
+            var x = new GameObject("newAreaLight");
+            x.AddComponent<LightComponent>();
+            x.GetComponent<LightComponent>().Type = LightComponent.LIGHT_TYPES.AREA;
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
+        private void AddEmptyGameObject(object sender, RoutedEventArgs e)
+        {
+            var x = new GameObject("newEmptyGameObject");
+            ThomasWrapper.Selection.SelectGameObject(x);
+        }
+
     }
 }


### PR DESCRIPTION
Change log:

- Hierarchy; "Right click -> Delete" option now working as intended.
- Hierarchy; "Right click -> Delete, Save as Prefab" now disabled unless an object is selected.
- Hierarchy; "Right click -> Create" added presets for game objects.

- Asset Browser; "Right click -> Open" now disabled unless a scene is selected.
- Asset Browser; Removed dead options such as Refresh, ImportNewAsset and more.
- Asset Browser; Double click functionality added for loading a scene.