### PR TITLE
Game object multi-selection

### DIFF
--- a/thomas/ThomasCore/include/imgui/ImGuizmo.cpp
+++ b/thomas/ThomasCore/include/imgui/ImGuizmo.cpp
@@ -1860,6 +1860,8 @@ namespace ImGuizmo
 
    void Manipulate(const float *view, const float *projection, OPERATION operation, MODE mode, float *matrix, float *deltaMatrix, float *snap, float *localBounds, float *boundsSnap)
    {
+
+	  
       ComputeContext(view, projection, matrix, mode);
 
       // set delta to identity

--- a/thomas/ThomasCore/src/thomas/ThomasCore.cpp
+++ b/thomas/ThomasCore/src/thomas/ThomasCore.cpp
@@ -64,7 +64,6 @@ namespace thomas
 		}
 
 		object::Object::Clean();
-		editor::EditorCamera::Instance()->Update();
 		resource::Shader::Update();	
 		Sound::Instance()->Update();
 	}

--- a/thomas/ThomasCore/src/thomas/editor/EditorCamera.h
+++ b/thomas/ThomasCore/src/thomas/editor/EditorCamera.h
@@ -59,6 +59,7 @@ namespace thomas
 			void MoveAndRotateCamera();
 			void SnapCameraToFocus();
 			object::GameObject* FindClickedGameObject();
+			void BoxSelect();
 			EditorCamera();
 			~EditorCamera();
 
@@ -74,6 +75,8 @@ namespace thomas
 			float m_speed;
 			bool m_manipulatorSnapping;	
 			bool m_hasSelectionChanged;
+			bool m_isBoxSelecting;
+			math::Rectangle m_boxSelectRect;
 			object::GameObject* m_selectedObject;
 			std::vector<object::GameObject*> m_selectedObjects;
 

--- a/thomas/ThomasCore/src/thomas/editor/EditorCamera.h
+++ b/thomas/ThomasCore/src/thomas/editor/EditorCamera.h
@@ -40,6 +40,7 @@ namespace thomas
 			void SelectObject(GameObject* gameObject);
 			void UnselectObject(GameObject* gameObject);
 			void UnselectObjects();
+			bool IsObjectSelected(GameObject* gameObject);
 
 		public:
 			void SetHasSelectionChanged(const bool & selectionChanged);
@@ -60,6 +61,7 @@ namespace thomas
 			void SnapCameraToFocus();
 			object::GameObject* FindClickedGameObject();
 			void BoxSelect();
+			void BeginBoxSelect();
 			EditorCamera();
 			~EditorCamera();
 

--- a/thomas/ThomasCore/src/thomas/editor/EditorCamera.h
+++ b/thomas/ThomasCore/src/thomas/editor/EditorCamera.h
@@ -36,6 +36,7 @@ namespace thomas
 		public:
 			bool HasSelectionChanged();
 			void ToggleManipulatorMode();
+			void ToggleObjectSelection(GameObject* gameObject);
 			void SelectObject(GameObject* gameObject);
 			void UnselectObject(GameObject* gameObject);
 			void UnselectObjects();

--- a/thomas/ThomasCore/src/thomas/object/component/Camera.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/Camera.cpp
@@ -245,10 +245,23 @@ namespace thomas
 				window.Offset(-center.x, -center.y);
 				rect.Offset(-center.x, -center.y);
 
+
+				if (rect.width < 0)
+				{
+					rect.x = rect.x + rect.width;
+					rect.width = abs(rect.width);
+				}
+
+				if (rect.height < 0)
+				{
+					rect.y = rect.y + rect.height;
+					rect.height = abs(rect.height);
+				}
+
 				float left = (float)rect.x / (float)window.x;
 				float right = (float)(rect.x + rect.width) / (float)(window.x + window.width);
 				float top = (float)rect.y / (float)window.y;
-				float bottom = (float)(rect.y + rect.width) / (float)(window.y + window.height);
+				float bottom = (float)(rect.y + rect.height) / (float)(window.y + window.height);
 
 				subFrustrum.LeftSlope *= left;
 				subFrustrum.RightSlope *= right;

--- a/thomas/ThomasCore/src/thomas/object/component/Camera.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/Camera.cpp
@@ -18,7 +18,7 @@ namespace thomas
 			void Camera::UpdateProjMatrix()
 			{
 				m_projMatrix = math::Matrix::CreatePerspectiveFieldOfView(math::DegreesToRadians(m_fov), GetViewport().AspectRatio(), m_near, m_far);
-				m_frustrum = math::BoundingFrustum(m_projMatrix);
+				m_frustrum = math::CreateFrustrumFromMatrixRH(m_projMatrix);
 			}
 
 			Camera::Camera(bool dontAddTolist)
@@ -233,6 +233,29 @@ namespace thomas
 				math::BoundingFrustum frustrum;
 				m_frustrum.Transform(frustrum, m_gameObject->m_transform->GetWorldMatrix());
 				return frustrum;
+			}
+
+			math::BoundingFrustum Camera::GetSubFrustrum(math::Rectangle rect)
+			{
+				
+				math::BoundingFrustum subFrustrum(GetFrustrum());
+
+				math::Rectangle window = math::Rectangle(GetViewport().x, GetViewport().y, GetViewport().width, GetViewport().height);
+				math::Vector2 center = window.Center();
+				window.Offset(-center.x, -center.y);
+				rect.Offset(-center.x, -center.y);
+
+				float left = (float)rect.x / (float)window.x;
+				float right = (float)(rect.x + rect.width) / (float)(window.x + window.width);
+				float top = (float)rect.y / (float)window.y;
+				float bottom = (float)(rect.y + rect.width) / (float)(window.y + window.height);
+
+				subFrustrum.LeftSlope *= left;
+				subFrustrum.RightSlope *= right;
+				subFrustrum.TopSlope *= top;
+				subFrustrum.BottomSlope *= bottom;
+				
+				return subFrustrum;
 			}
 
 			void Camera::CopyFrameData()

--- a/thomas/ThomasCore/src/thomas/object/component/Camera.h
+++ b/thomas/ThomasCore/src/thomas/object/component/Camera.h
@@ -67,6 +67,7 @@ namespace thomas
 				int GetTargetDisplayIndex();
 
 				math::BoundingFrustum GetFrustrum();
+				math::BoundingFrustum GetSubFrustrum(math::Rectangle rect);
 
 				void CopyFrameData();
 				CAMERA_FRAME_DATA& GetFrameData();

--- a/thomas/ThomasCore/src/thomas/object/component/Transform.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/Transform.cpp
@@ -89,7 +89,7 @@ namespace thomas
 			{
 				if (target == GetPosition())
 					return;
-				m_localWorldMatrix = math::Matrix::CreateWorld(eye, target - eye, m_localWorldMatrix.Up());
+				m_localWorldMatrix = math::Matrix::CreateWorld(eye, target - eye, math::Vector3::Up);
 				
 				Decompose();
 				SetDirty(true);

--- a/thomas/ThomasCore/src/thomas/object/component/Transform.cpp
+++ b/thomas/ThomasCore/src/thomas/object/component/Transform.cpp
@@ -142,6 +142,17 @@ namespace thomas
 				return Translate(math::Vector3(x, y, z));
 			}
 
+			void Transform::Scale(math::Vector3 scale)
+			{
+				SetLocalScale(m_localScale + scale);
+				SetDirty(true);
+			}
+
+			void Transform::Scale(float x, float y, float z)
+			{
+				Scale(math::Vector3(x, y, z));
+			}
+
 			math::Vector3 Transform::GetPosition()
 			{
 				if (m_parent)

--- a/thomas/ThomasCore/src/thomas/object/component/Transform.h
+++ b/thomas/ThomasCore/src/thomas/object/component/Transform.h
@@ -40,7 +40,8 @@ namespace thomas
 				void RotateByAxis(math::Vector3 axis, float angle);
 				void Translate(math::Vector3 translation);
 				void Translate(float x, float y, float z);
-
+				void Scale(math::Vector3 scale);
+				void Scale(float x, float y, float z);
 
 				math::Vector3 GetPosition();
 				math::Quaternion GetRotation();

--- a/thomas/ThomasCore/src/thomas/utils/Math.cpp
+++ b/thomas/ThomasCore/src/thomas/utils/Math.cpp
@@ -35,6 +35,57 @@ namespace DirectX
 		}
 
 
+		BoundingFrustum CreateFrustrumFromMatrixRH(CXMMATRIX projection)
+		{
+			BoundingFrustum Out;
+			// Corners of the projection frustum in homogenous space.
+			static XMVECTORF32 HomogenousPoints[6] =
+			{
+			 { 1.0f,  0.0f, -1.0f, 1.0f },   // right (at far plane)
+			 { -1.0f,  0.0f, -1.0f, 1.0f },   // left
+			 { 0.0f,  1.0f, -1.0f, 1.0f },   // top
+			 { 0.0f, -1.0f, -1.0f, 1.0f },   // bottom
+
+			 { 0.0f, 0.0f, 1.0f, 1.0f },    // near
+			 { 0.0f, 0.0f, 0.0f, 1.0f }     // far
+			};
+
+			XMVECTOR Determinant;
+			XMMATRIX matInverse = XMMatrixInverse(&Determinant, projection);
+
+			// Compute the frustum corners in world space.
+			Vector4 Points[6];
+
+			for (size_t i = 0; i < 6; ++i)
+			{
+				// Transform point.
+				Points[i] = XMVector4Transform(HomogenousPoints[i], matInverse);
+			}
+
+			Out.Origin = XMFLOAT3(0.0f, 0.0f, 0.0f);
+			Out.Orientation = XMFLOAT4(0.0f, 0.0f, 0.0f, 1.0f);
+
+			// Compute the slopes.
+			Points[0] = Points[0] * (Vector4)XMVectorReciprocal(XMVectorSplatZ(Points[0]));
+			Points[1] = Points[1] * (Vector4)XMVectorReciprocal(XMVectorSplatZ(Points[1]));
+			Points[2] = Points[2] * (Vector4)XMVectorReciprocal(XMVectorSplatZ(Points[2]));
+			Points[3] = Points[3] * (Vector4)XMVectorReciprocal(XMVectorSplatZ(Points[3]));
+
+			Out.RightSlope = XMVectorGetX(Points[0]);
+			Out.LeftSlope = XMVectorGetX(Points[1]);
+			Out.TopSlope = XMVectorGetY(Points[2]);
+			Out.BottomSlope = XMVectorGetY(Points[3]);
+
+			// Compute near and far.
+			Points[4] = Points[4] * (Vector4)XMVectorReciprocal(XMVectorSplatW(Points[4]));
+			Points[5] = Points[5] * (Vector4)XMVectorReciprocal(XMVectorSplatW(Points[5]));
+
+			Out.Near = XMVectorGetZ(Points[4]);
+			Out.Far = XMVectorGetZ(Points[5]);
+
+			return Out;
+		}
+
 		Quaternion getRotationTo(Vector3 from, Vector3 dest)
 		{
 			// Based on Stan Melax's article in Game Programming Gems

--- a/thomas/ThomasCore/src/thomas/utils/Math.h
+++ b/thomas/ThomasCore/src/thomas/utils/Math.h
@@ -19,6 +19,8 @@ namespace DirectX
 		using DirectX::BoundingOrientedBox;
 
 
+		BoundingFrustum CreateFrustrumFromMatrixRH(CXMMATRIX projection);
+
 		Quaternion getRotationTo(Vector3 from, Vector3 dest);
 
 		inline float DegreesToRadians(const float & degree)

--- a/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml.cs
+++ b/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml.cs
@@ -295,11 +295,13 @@ namespace ThomasEditor
                     {
                         Inspector.instance.SelectedObject = (GameObject)item.Data;
                         ThomasWrapper.Selection.UnselectGameObjects();
+
+                        
                         foreach (var selectedObject in GetSelection())
                         {
                             GameObject selectedGObject = selectedObject.Data as GameObject;
                             if (!ThomasWrapper.Selection.Contain(selectedGObject))
-                                ThomasWrapper.Selection.SelectGameObject(selectedGObject);
+                                ThomasWrapper.Selection.SelectGameObject(selectedGObject, false);
 
 
                         }

--- a/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml.cs
+++ b/thomas/ThomasEditor/Elements/GameObjectHierarchy.xaml.cs
@@ -44,10 +44,12 @@ namespace ThomasEditor
             m_hierarchyNodes = new ObservableCollection<TreeItemViewModel>();
             hierarchy.ItemsSource = m_hierarchyNodes;
             Scene.OnCurrentSceneChanged += Scene_OnCurrentSceneChanged;
-
         }
 
-
+        private void Ref_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            
+        }
 
         private void Scene_OnCurrentSceneChanged(Scene oldScene, Scene newScene)
         {
@@ -233,6 +235,7 @@ namespace ThomasEditor
                 if (items.Contains(node.Data))
                 {
                     node.IsSelected = select;
+
                 }
                 SelectOrDeselectInTree(node.Children, items, select);
             }
@@ -254,6 +257,7 @@ namespace ThomasEditor
                 if (e.NewItems != null)
                 {
                     SelectOrDeselectInTree(m_hierarchyNodes.ToList(), e.NewItems, true);
+                    Inspector.instance.SelectedObject = e.NewItems[0];
                 }
                 if (e.OldItems != null)
                 {
@@ -263,7 +267,11 @@ namespace ThomasEditor
                 if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
                 {
                     if (m_hierarchyNodes.Count > 0)
+                    {
                         ResetTree(m_hierarchyNodes.ToList());
+                        Inspector.instance.SelectedObject = null;
+                    }
+                        
                 }
             }));
 
@@ -275,6 +283,7 @@ namespace ThomasEditor
             this.Dispatcher.BeginInvoke((Action)(() =>
             {
                 ThomasWrapper.Selection.Ref.CollectionChanged -= SceneSelectedGameObjectChanged;
+                
                 if (!wasUnselected)
                     AssetBrowser.instance.UnselectItem();
                 wasUnselected = false;
@@ -285,9 +294,17 @@ namespace ThomasEditor
                     if (item != null)
                     {
                         Inspector.instance.SelectedObject = (GameObject)item.Data;
+                        ThomasWrapper.Selection.UnselectGameObjects();
+                        foreach (var selectedObject in GetSelection())
+                        {
+                            GameObject selectedGObject = selectedObject.Data as GameObject;
+                            if (!ThomasWrapper.Selection.Contain(selectedGObject))
+                                ThomasWrapper.Selection.SelectGameObject(selectedGObject);
 
-                        if (!ThomasWrapper.Selection.Contain((GameObject)item.Data))
-                            ThomasWrapper.Selection.SelectGameObject((GameObject)item.Data);
+
+                        }
+                        //if (!ThomasWrapper.Selection.Contain((GameObject)item.Data))
+                        //    ThomasWrapper.Selection.SelectGameObject((GameObject)item.Data);
                         hiearchyContextMenu.DataContext = true;
                     }
                 }

--- a/thomas/ThomasEditor/Inspectors/ExtendedPropertyGrid.xaml
+++ b/thomas/ThomasEditor/Inspectors/ExtendedPropertyGrid.xaml
@@ -107,7 +107,7 @@
 
     </UserControl.Resources>
 
-    <xctk:PropertyGrid x:Name="_grid" DataContextChanged="PropertyGrid_DataContextChanged" IsCategorized="False" UpdateTextBoxSourceOnEnterKey="True"  Background="Aqua" AutoGenerateProperties="True" SelectedObject="{Binding}" ShowAdvancedOptions="False" ShowSummary="False" ShowSortOptions="False" ShowTitle="False" ShowSearchBox="False" Loaded="PropertyGrid_Loaded">
+    <xctk:PropertyGrid x:Name="_grid" DataContextChanged="PropertyGrid_DataContextChanged" IsCategorized="True" IsMiscCategoryLabelHidden="True" UpdateTextBoxSourceOnEnterKey="True"  Background="Aqua" AutoGenerateProperties="True" SelectedObject="{Binding}" ShowAdvancedOptions="False" ShowSummary="False" ShowSortOptions="False" ShowTitle="False" ShowSearchBox="False" Loaded="PropertyGrid_Loaded">
         <xctk:PropertyGrid.EditorDefinitions>
             <xctk:EditorTemplateDefinition EditingTemplate="{StaticResource Vector2Editor}">
                 <xctk:EditorTemplateDefinition.TargetProperties>

--- a/thomas/ThomasEditor/Inspectors/ExtendedPropertyGrid.xaml.cs
+++ b/thomas/ThomasEditor/Inspectors/ExtendedPropertyGrid.xaml.cs
@@ -27,6 +27,7 @@ namespace ThomasEditor
                 InitializeComponent();
             }
 
+
             private void PropertyGrid_Loaded(object sender, RoutedEventArgs e)
             {
                 PropertyGrid grid = sender as PropertyGrid;

--- a/thomas/ThomasEditor/Inspectors/ListEditor.xaml
+++ b/thomas/ThomasEditor/Inspectors/ListEditor.xaml
@@ -20,7 +20,7 @@
             <RowDefinition Height="auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <xctk:IntegerUpDown Grid.Row="0" IsReadOnly="False" AllowSpin="False" Minimum="0"
+        <xctk:IntegerUpDown Grid.Row="0" IsReadOnly="False" AllowSpin="False" Minimum="0" Foreground="White"
             Value="{Binding Value.Count, Mode=OneWay}"
             ValueChanged="PropertyGridEditorIntegerUpDown_ValueChanged"
                             UpdateValueOnEnterKey="True"/>

--- a/thomas/ThomasEditor/Themes/PropertyGridStyle.xaml
+++ b/thomas/ThomasEditor/Themes/PropertyGridStyle.xaml
@@ -11,7 +11,7 @@
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <xceed:InverseBoolConverter x:Key="InverseBoolConverter" />
     <xceed:ExpandableObjectMarginConverter x:Key="ExpandableObjectMarginConverter" />
-
+    <xceed:IsDefaultCategoryConverter x:Key="IsDefaultCategoryConverter" />
     <x:Static x:Key="EmptyString" Member="sys:String.Empty" />
 
     <SolidColorBrush x:Key="MouseOverBorderBrush" Color="#FFFFB700" />
@@ -98,7 +98,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <ToggleButton Template="{StaticResource ExpanderToggleButton}" IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" OverridesDefaultStyle="True" />
-                                <ContentPresenter Grid.Column="1" Margin="1" RecognizesAccessKey="True" ContentSource="Header" TextElement.FontWeight="Bold" />
+                                <ContentPresenter Grid.Column="1" Margin="1" RecognizesAccessKey="True" ContentSource="Header" TextElement.FontWeight="Bold" TextElement.Foreground="White" />
                             </Grid>
                         </Border>
                         <Border Visibility="Collapsed" Grid.Row="1" x:Name="ExpandSite" Background="{DynamicResource PanelBackground}" Padding="10 0 0 0">
@@ -505,6 +505,22 @@
                                                                 </ControlTemplate>
                                                             </Setter.Value>
                                                         </Setter>
+                                                        <Style.Triggers>
+                                                            <MultiDataTrigger>
+                                                                <MultiDataTrigger.Conditions>
+                                                                    <Condition Binding="{Binding Name, Converter={StaticResource IsDefaultCategoryConverter}}" Value="True" />
+                                                                    <Condition Binding="{Binding IsMiscCategoryLabelHidden, RelativeSource={RelativeSource AncestorType={x:Type xceed:PropertyGrid}}}" Value="True" />
+                                                                </MultiDataTrigger.Conditions>
+                                                                <Setter Property="Template">
+                                                                    <Setter.Value>
+                                                                        <ControlTemplate TargetType="{x:Type GroupItem}">
+                                                                            <!-- No Expander for the Misc Category if IsMiscCategoryLabelHidden == true-->
+                                                                            <ItemsPresenter />
+                                                                        </ControlTemplate>
+                                                                    </Setter.Value>
+                                                                </Setter>
+                                                            </MultiDataTrigger>
+                                                        </Style.Triggers>
                                                     </Style>
                                                 </GroupStyle.ContainerStyle>
                                             </GroupStyle>
@@ -639,7 +655,7 @@
                                         <TextBlock Grid.Column="1" Text="{Binding DisplayName, RelativeSource={RelativeSource TemplatedParent}}" 
                                                          HorizontalAlignment="Stretch" 
                                                          VerticalAlignment="Center"
-                                                         TextTrimming="CharacterEllipsis"
+                                                         TextTrimming="CharacterEllipsis" Foreground="White"
                                                    />
                                     </Grid>
 

--- a/thomas/ThomasEditor/ThomasEditor.csproj
+++ b/thomas/ThomasEditor/ThomasEditor.csproj
@@ -155,23 +155,23 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsFormsIntegration" />
-    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.2.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.2.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.4.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.4.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.2.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.2.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.4.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.4.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.2.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.2.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.4.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.4.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.2.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.2.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.4.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.4.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.DataGrid, Version=3.2.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.2.0\lib\net40\Xceed.Wpf.DataGrid.dll</HintPath>
+    <Reference Include="Xceed.Wpf.DataGrid, Version=3.4.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.4.0\lib\net40\Xceed.Wpf.DataGrid.dll</HintPath>
     </Reference>
-    <Reference Include="Xceed.Wpf.Toolkit, Version=3.2.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.3.2.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
+    <Reference Include="Xceed.Wpf.Toolkit, Version=3.4.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.4.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/thomas/ThomasEditor/packages.config
+++ b/thomas/ThomasEditor/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="2.3.0" targetFramework="net461" />
-  <package id="Extended.Wpf.Toolkit" version="3.2.0" targetFramework="net461" />
+  <package id="Extended.Wpf.Toolkit" version="3.4.0" targetFramework="net471" />
   <package id="PropertyTools.Wpf" version="2.0.1" targetFramework="net461" />
   <package id="System.Collections" version="4.0.11" targetFramework="net461" />
   <package id="System.Console" version="4.0.0" targetFramework="net461" />

--- a/thomas/ThomasEditor/scriptComponent test/TestComponent.cs
+++ b/thomas/ThomasEditor/scriptComponent test/TestComponent.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using ThomasEngine;
+using System.ComponentModel;
+
 namespace ThomasEditor
 {
     public class TestComponent : ScriptComponent
@@ -15,6 +17,7 @@ namespace ThomasEditor
         public AudioClip audioClip { get; set; }
         public Material mat { get; set; }
         public Model m { get; set; }
+        [Category("customCategory")]
         public GameObject coolPrefab { get; set; }
         public RenderComponent otherObjectsRender { get; set; }
         public List<GameObject> niceList { get; set; } = new List<GameObject> { null, null };

--- a/thomas/ThomasEngine/src/ThomasManaged.cpp
+++ b/thomas/ThomasEngine/src/ThomasManaged.cpp
@@ -156,6 +156,7 @@ namespace ThomasEngine {
 						gameObject->Update();
 					}
 				}
+				editor::EditorCamera::Instance()->Update();
 
 				//Rendering
 				thomas::graphics::Renderer::Instance()->ClearCommands();
@@ -203,7 +204,6 @@ namespace ThomasEngine {
 					}
 					Stop();
 				}
-					
 					
 			}
 			finally

--- a/thomas/ThomasEngine/src/ThomasSelection.cpp
+++ b/thomas/ThomasEngine/src/ThomasSelection.cpp
@@ -25,9 +25,8 @@ namespace ThomasEngine {
 		lockOwner = Thread::CurrentThread->Name;
 #endif
 		try {
-			m_SelectedGameObjects->Clear();
 			m_SelectedGameObjects->Add(gObj);
-			thomas::editor::EditorCamera::Instance()->SelectObject((thomas::object::GameObject*)gObj->nativePtr);
+			thomas::editor::EditorCamera::Instance()->ToggleObjectSelection((thomas::object::GameObject*)gObj->nativePtr);
 		}
 		catch (Exception^ e) {
 			m_SelectedGameObjects->Clear();

--- a/thomas/ThomasEngine/src/ThomasSelection.cpp
+++ b/thomas/ThomasEngine/src/ThomasSelection.cpp
@@ -17,14 +17,21 @@ namespace ThomasEngine {
 	{
 	}
 
-
-	void ThomasSelection::SelectGameObject(GameObject^ gObj)
+	void ThomasSelection::SelectGameObject(GameObject^ gObj) 
+	{
+		SelectGameObject(gObj, true);
+	}
+	void ThomasSelection::SelectGameObject(GameObject^ gObj, bool clearSelection)
 	{
 		Monitor::Enter(m_lock);
 #if _DEBUG
 		lockOwner = Thread::CurrentThread->Name;
 #endif
 		try {
+			if (clearSelection) {
+				m_SelectedGameObjects->Clear();
+				thomas::editor::EditorCamera::Instance()->UnselectObjects();
+			}
 			m_SelectedGameObjects->Add(gObj);
 			thomas::editor::EditorCamera::Instance()->ToggleObjectSelection((thomas::object::GameObject*)gObj->nativePtr);
 		}

--- a/thomas/ThomasEngine/src/ThomasSelection.h
+++ b/thomas/ThomasEngine/src/ThomasSelection.h
@@ -19,6 +19,7 @@ namespace ThomasEngine {
 		~ThomasSelection();
 
 		void SelectGameObject(GameObject^ gObj);
+		void SelectGameObject(GameObject^ gObj, bool clearSelection);
 		void SelectGameObject(System::Guid guid);
 		void UnSelectGameObject(GameObject^ gObj);
 


### PR DESCRIPTION
GameObjects can now be multi-selected. When multi-selected they will all highlight and the transform gizmo will affect all selected gameObjects.

How to select multiple game objects:
* Select multi-objects from the hierarchy.
* Hold Ctrl and click on game objects in the scene.
* Click and drag in the scene to activate box select. Then just make sure the gameObject is contained in the box.

Box selection can feel a bit laggy when selecting an object. This is because of the hierarchy/inspector focus bug.