### PR TITLE
concave mesh collider

### DIFF
--- a/thomas/ThomasCore/src/thomas/Physics.cpp
+++ b/thomas/ThomasCore/src/thomas/Physics.cpp
@@ -31,14 +31,14 @@ namespace thomas
 		s_debugDraw = std::make_unique<graphics::BulletDebugDraw>();
 		//Set states
 		s_world->setGravity(btVector3(0, -9.82f, 0));
-		s_debugDraw->setDebugMode(btIDebugDraw::DBG_DrawWireframe);
+		s_debugDraw->setDebugMode(btIDebugDraw::DBG_DrawWireframe | btIDebugDraw::DBG_FastWireframe);
 		s_world->setDebugDrawer(s_debugDraw.get());
 
 		gContactStartedCallback = Physics::CollisionStarted;
 		gContactProcessedCallback = Physics::CollisionProcessed;
 		gContactEndedCallback = Physics::CollisionEnded;
 		
-		s_debugDraw->setDebugMode(btIDebugDraw::DBG_DrawConstraintLimits );
+		//s_debugDraw->setDebugMode(btIDebugDraw::DBG_DrawConstraintLimits );
 		return true;
 	}
 	void Physics::AddRigidBody(object::component::Rigidbody * rigidBody)

--- a/thomas/ThomasCore/src/thomas/editor/gizmos/GizmoRenderBuffer.cpp
+++ b/thomas/ThomasCore/src/thomas/editor/gizmos/GizmoRenderBuffer.cpp
@@ -23,6 +23,7 @@ namespace thomas {
 				// Local data copy.
 				uint32_t bytes = cmd.numVertex * sizeof(math::Vector3);
 				math::Vector3 * alloc = reinterpret_cast<math::Vector3*>(m_alloc.allocate(bytes, sizeof(float)));
+
 				std::memcpy(alloc, cmd.vertexData, bytes);
 				cmd.vertexData = alloc;
 				// Increment

--- a/thomas/ThomasCore/src/thomas/editor/gizmos/GizmoRenderBuffer.h
+++ b/thomas/ThomasCore/src/thomas/editor/gizmos/GizmoRenderBuffer.h
@@ -9,7 +9,7 @@
 namespace thomas {
 	namespace editor {
 		namespace gizmo {
-			constexpr uint32_t GIZMO_BUFFER_MEMORY = 4096*16;
+			constexpr uint32_t GIZMO_BUFFER_MEMORY = 16384 *16;
 			constexpr uint32_t GIZMO_DRAW_COMMAND_INIT = 79*128;
 
 			class GizmoRenderBuffer

--- a/thomas/ThomasCore/src/thomas/object/component/physics/MeshCollider.h
+++ b/thomas/ThomasCore/src/thomas/object/component/physics/MeshCollider.h
@@ -18,7 +18,14 @@ namespace thomas
 				resource::Model* GetMesh();
 				void SetMesh(resource::Model* value);
 				void OnDrawGizmosSelected();
+				void SetConcave(bool value);
+				bool GetConcave();
 			private:
+				void RecalcCollider();
+				void CalculateConvex();
+				void CalculateConcave();
+			private:
+				bool m_concave = false;
 				resource::Model* m_model = nullptr;
 			};
 		}

--- a/thomas/ThomasEditor/App.config
+++ b/thomas/ThomasEditor/App.config
@@ -96,7 +96,7 @@
 <userSettings>
         <ThomasEditor.Properties.Settings>
                 <setting name="latestProjectPath" serializeAs="String">
-                        <value/>
+                        <value />
                 </setting>
                 <setting name="Top" serializeAs="String">
                         <value>0</value>
@@ -111,6 +111,12 @@
                         <value>800</value>
                 </setting>
                 <setting name="Maximized" serializeAs="String">
+                        <value>False</value>
+                </setting>
+                <setting name="RenderEditor" serializeAs="String">
+                        <value>True</value>
+                </setting>
+                <setting name="RenderPhysicsDebug" serializeAs="String">
                         <value>False</value>
                 </setting>
         </ThomasEditor.Properties.Settings>

--- a/thomas/ThomasEditor/MainWindow.xaml
+++ b/thomas/ThomasEditor/MainWindow.xaml
@@ -96,8 +96,8 @@
                 <MenuItem Header="_Tools">
                     <MenuItem Header="_Options" Click="OpenOptionsWindow"/>
                     <MenuItem Header="_Reload Assembly" Click="ReloadAssembly"/>
-                    <MenuItem Header="_Toggle Editor Rendering" IsCheckable="True" IsChecked="True" Click="MenuItem_ToggleEditorRendering"/>
-                        <MenuItem Header="_Toggle Physics Debug" IsCheckable="True" IsChecked="True" Click="MenuItem_TogglePhysicsDebug"/>
+                    <MenuItem x:Name="menuItem_editorRendering" Header="_Toggle Editor Rendering" IsCheckable="True" Click="MenuItem_ToggleEditorRendering"/>
+                        <MenuItem x:Name="menuItem_physicsDebug" Header="_Toggle Physics Debug" IsCheckable="True" Click="MenuItem_TogglePhysicsDebug"/>
                     </MenuItem>
             </Menu>
             <WrapPanel Grid.Row="1" Height="40">

--- a/thomas/ThomasEditor/MainWindow.xaml.cs
+++ b/thomas/ThomasEditor/MainWindow.xaml.cs
@@ -74,7 +74,11 @@ namespace ThomasEditor
             ScriptingManger.scriptReloadStarted += ScriptingManger_scriptReloadStarted;
             ScriptingManger.scriptReloadFinished += ScriptingManger_scriptReloadFinished;
 
+            ThomasWrapper.RenderEditor = Properties.Settings.Default.RenderEditor;
+            ThomasWrapper.RenderPhysicsDebug = Properties.Settings.Default.RenderPhysicsDebug;
 
+            menuItem_editorRendering.IsChecked = ThomasWrapper.RenderEditor;
+            menuItem_physicsDebug.IsChecked = ThomasWrapper.RenderPhysicsDebug;
 
         }
 
@@ -612,12 +616,18 @@ namespace ThomasEditor
 
         private void MenuItem_ToggleEditorRendering(object sender, RoutedEventArgs e)
         {
-            ThomasWrapper.ToggleEditorRendering();
+            MenuItem item = sender as MenuItem;
+            ThomasWrapper.RenderEditor = item.IsChecked;
+            Properties.Settings.Default.RenderEditor = item.IsChecked;
+            Properties.Settings.Default.Save();
         }
 
         private void MenuItem_TogglePhysicsDebug(object sender, RoutedEventArgs e)
         {
-            ThomasWrapper.TogglePhysicsDebug();
+            MenuItem item = sender as MenuItem;
+            ThomasWrapper.RenderPhysicsDebug = item.IsChecked;
+            Properties.Settings.Default.RenderPhysicsDebug = item.IsChecked;
+            Properties.Settings.Default.Save();
         }
 
 

--- a/thomas/ThomasEditor/Properties/Settings.Designer.cs
+++ b/thomas/ThomasEditor/Properties/Settings.Designer.cs
@@ -94,5 +94,29 @@ namespace ThomasEditor.Properties {
                 this["Maximized"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool RenderEditor {
+            get {
+                return ((bool)(this["RenderEditor"]));
+            }
+            set {
+                this["RenderEditor"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RenderPhysicsDebug {
+            get {
+                return ((bool)(this["RenderPhysicsDebug"]));
+            }
+            set {
+                this["RenderPhysicsDebug"] = value;
+            }
+        }
     }
 }

--- a/thomas/ThomasEditor/Properties/Settings.settings
+++ b/thomas/ThomasEditor/Properties/Settings.settings
@@ -20,5 +20,11 @@
     <Setting Name="Maximized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="RenderEditor" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="RenderPhysicsDebug" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/thomas/ThomasEngine/src/ThomasManaged.cpp
+++ b/thomas/ThomasEngine/src/ThomasManaged.cpp
@@ -178,7 +178,7 @@ namespace ThomasEngine {
 				//Rendering
 				if (WindowManager::Instance())
 				{
-					if (WindowManager::Instance()->GetEditorWindow() && renderingEditor)
+					if (WindowManager::Instance()->GetEditorWindow() && RenderEditor)
 					{
 						editor::EditorCamera::Instance()->Render();
 						//GUI::ImguiStringUpdate(thomas::ThomasTime::GetFPS().ToString(), Vector2(Window::GetEditorWindow()->GetWidth() - 100, 0)); TEMP FPS stuff :)
@@ -329,6 +329,10 @@ namespace ThomasEngine {
 		shouldStop = false;
 	}
 
+	bool ThomasWrapper::RenderPhysicsDebug::get() { return thomas::Physics::Physics::s_drawDebug; }
+
+	void ThomasWrapper::RenderPhysicsDebug::set(bool value) { thomas::Physics::Physics::s_drawDebug = value; }
+
 	float ThomasWrapper::FrameRate::get() { return float(thomas::ThomasTime::GetFPS()); }
 
 	void ThomasWrapper::SetEditorGizmoManipulatorOperation(ManipulatorOperation op)
@@ -352,12 +356,4 @@ namespace ThomasEngine {
 		return inEditor;
 	}
 
-	void ThomasWrapper::ToggleEditorRendering()
-	{
-		renderingEditor = !renderingEditor;
-	}
-	void ThomasWrapper::TogglePhysicsDebug()
-	{
-		Physics::s_drawDebug = !Physics::s_drawDebug;
-	}
 }

--- a/thomas/ThomasEngine/src/ThomasManaged.h
+++ b/thomas/ThomasEngine/src/ThomasManaged.h
@@ -17,7 +17,6 @@ namespace ThomasEngine {
 		static bool inEditor = false;
 		static float cpuTime = 0.0f;
 		static bool showStatistics = false;
-		static bool renderingEditor = true;
 		static Thread^ mainThread;
 		static Thread^ renderThread;
 		static bool playing = false;	
@@ -78,10 +77,13 @@ namespace ThomasEngine {
 	
 		static bool InEditor();
 
-		static void ToggleEditorRendering();
-		static void TogglePhysicsDebug();
 	public:
-
+		static bool RenderEditor = true;
+		static property bool RenderPhysicsDebug
+		{
+			bool get();
+			void set(bool value);
+		}
 		static property float FrameRate
 		{
 			float get();

--- a/thomas/ThomasEngine/src/object/component/physics/MeshCollider.cpp
+++ b/thomas/ThomasEngine/src/object/component/physics/MeshCollider.cpp
@@ -44,4 +44,14 @@ namespace ThomasEngine
 		else
 			((thomas::object::component::MeshCollider*)nativePtr)->SetMesh(nullptr);
 	}
+
+	bool MeshCollider::concave::get()
+	{
+		return ((thomas::object::component::MeshCollider*)nativePtr)->GetConcave();
+	}
+
+	void MeshCollider::concave::set(bool value)
+	{
+		((thomas::object::component::MeshCollider*)nativePtr)->SetConcave(value);
+	}
 }

--- a/thomas/ThomasEngine/src/object/component/physics/MeshCollider.h
+++ b/thomas/ThomasEngine/src/object/component/physics/MeshCollider.h
@@ -17,5 +17,11 @@ namespace ThomasEngine
 			void set(Model^ value);
 
 		}
+
+		property bool concave
+		{
+			bool get();
+			void set(bool value);
+		}
 	};
 }


### PR DESCRIPTION
Added a checkbox on mesh collider to create a concave collider instead of the standard convex.

A concave collider is static, so it cannot be moved (at least not via rigidbody. Moving transform seems to work, but not intentional.)
Not supported: changing the mesh or toggle between concave/convex during play.

**Note: Mesh colliders are the most costly colliders and should be avoided in most cases. When used make sure the mesh does not have too many verts. A separate mesh could be used for the collision that is much more simpler than the rendering mesh.**

To test:
* Add a meshcollider and give it a concave mesh (like teapot).
* try both non concave and concave with physics debug to see the difference.
* Try having a rigidbody interact with it (A ball dropping on it for example)