### PR TITLE
Fixed the bug

### DIFF
--- a/thomas/ThomasCore/src/thomas/utils/AssimpLoader.cpp
+++ b/thomas/ThomasCore/src/thomas/utils/AssimpLoader.cpp
@@ -132,7 +132,6 @@ namespace thomas
 				aiProcess_GenSmoothNormals |
 				aiProcess_CalcTangentSpace |
 				aiProcess_FlipUVs |
-				aiProcess_ConvertToLeftHanded |
 				aiProcess_LimitBoneWeights			// Bone weight limit (4 by default)
 			);
 
@@ -169,7 +168,7 @@ namespace thomas
 			skelConstruct.m_Commands.m_IncludeAllKeyframedChannels = false;
 			skelConstruct.m_Commands.m_IgnoreLeafChains = false;
 
-			skelConstruct.m_rootID.insert("mixamorig:hips");
+			skelConstruct.m_rootID.insert("mixamorig:hips"); //TODO: is this a hack?
 
 
 			const aiScene* scene = LoadScene(importer, path);


### PR DESCRIPTION
* Animations and models should now load right-handed.

Test by:
* Loading an asymmetrical animation (such as Quarterback Pass) before and after applying the fix.