### PR TITLE
Bugfix/removal of dod game object

### DIFF
--- a/thomas/ThomasEditor/Inspectors/GameObjectInspector.xaml
+++ b/thomas/ThomasEditor/Inspectors/GameObjectInspector.xaml
@@ -41,14 +41,14 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
-            <CheckBox Margin="10"  IsChecked="{Binding activeSelf}" Grid.Column="0" HorizontalAlignment="Center" ToolTip="Active?"/>
+            <!--<CheckBox Margin="10"  IsChecked="{Binding activeSelf}" Grid.Column="0" HorizontalAlignment="Center" ToolTip="Active?"/>-->
             <TextBox VerticalAlignment="Top" Height="20" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Margin="5" Grid.Column="1"/>
             <!--<TextBox VerticalAlignment="Top" Height="20" Text="{Binding GroupIDSelf, UpdateSourceTrigger=LostFocus}" Margin="5,30,167,0" Grid.Column="1"/>-->
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Width="263" RenderTransformOrigin="0.507,0.444" Grid.ColumnSpan="2" Margin="0,30,0,2" Grid.Column="1">
                 <TextBlock Text="Layer" Width="41" VerticalAlignment="Center"/>
                 <ComboBox x:Name="LayerBox" SelectedIndex="{Binding Layer}" Width="163" VerticalAlignment="Center"></ComboBox>
             </StackPanel>
-            <CheckBox Content="Static"  IsChecked="{Binding staticSelf}" Grid.Column="2" Margin="3,10" HorizontalAlignment="Right" Width="46"/>
+            <!-- <CheckBox Content="Static"  IsChecked="{Binding staticSelf}" Grid.Column="2" Margin="3,10" HorizontalAlignment="Right" Width="46"/> -->
         </Grid>
 
         <ItemsControl x:Name="componentItemList" ItemsSource="{Binding Components}" Grid.Row="1" Background="#333333" HorizontalAlignment="Stretch">

--- a/thomas/ThomasEngine/src/ThomasManaged.cpp
+++ b/thomas/ThomasEngine/src/ThomasManaged.cpp
@@ -187,49 +187,49 @@ namespace ThomasEngine {
 		// Enter async. state 
 #ifdef _EDITOR
 					// This is only relevant if we are running with editor, should be removed when build
-		for each(GameObject^ gameObject in CurrentScene->GameObjects)
-		{
-			if (gameObject->MoveStaticGroup())
-			{
-				// Fetch the adress of where an object might be moved to
-				thomas::object::Object* new_temp = gameObject->nativePtr;
+		//for each(GameObject^ gameObject in CurrentScene->GameObjects)
+		//{
+		//	if (gameObject->MoveStaticGroup())
+		//	{
+		//		// Fetch the adress of where an object might be moved to
+		//		thomas::object::Object* new_temp = gameObject->nativePtr;
 
-				// Fetch the adress of the object that might be moved
-				thomas::object::Object* old_native = gameObject->moveStaticGroup();
+		//		// Fetch the adress of the object that might be moved
+		//		thomas::object::Object* old_native = gameObject->moveStaticGroup();
 
-				// Find the wrapped gameobject of the object that might be moved
-				GameObject^ temp = CurrentScene->Find(static_cast<thomas::object::GameObject*>(old_native));
+		//		// Find the wrapped gameobject of the object that might be moved
+		//		GameObject^ temp = CurrentScene->Find(static_cast<thomas::object::GameObject*>(old_native));
 
-				if (temp) // If temp is nullptr, no managed object has been invalidated, no move will be done.
-					temp->nativePtr = new_temp; // Nothing becomes invalidated if we don't do anything.
-			}
+		//		if (temp) // If temp is nullptr, no managed object has been invalidated, no move will be done.
+		//			temp->nativePtr = new_temp; // Nothing becomes invalidated if we don't do anything.
+		//	}
 
-			else if (gameObject->MakeStatic())
-			{
-				thomas::object::Object* new_temp = gameObject->nativePtr;
+		//	else if (gameObject->MakeStatic())
+		//	{
+		//		thomas::object::Object* new_temp = gameObject->nativePtr;
 
-				thomas::object::Object* old_native = gameObject->setStatic();
+		//		thomas::object::Object* old_native = gameObject->setStatic();
 
-				GameObject^ temp = CurrentScene->Find(static_cast<thomas::object::GameObject*>(old_native));
+		//		GameObject^ temp = CurrentScene->Find(static_cast<thomas::object::GameObject*>(old_native));
 
-				if (temp) // If temp is nullptr, no managed object has been invalidated.
-					temp->nativePtr = new_temp; // Nothing becomes invalidated if we don't do anything.
+		//		if (temp) // If temp is nullptr, no managed object has been invalidated.
+		//			temp->nativePtr = new_temp; // Nothing becomes invalidated if we don't do anything.
 
-			}
+		//	}
 
-			else if (gameObject->MakeDynamic())
-			{
-				thomas::object::Object* new_temp = gameObject->nativePtr;
+		//	else if (gameObject->MakeDynamic())
+		//	{
+		//		thomas::object::Object* new_temp = gameObject->nativePtr;
 
-				thomas::object::Object* old_native = gameObject->setDynamic();
+		//		thomas::object::Object* old_native = gameObject->setDynamic();
 
-				GameObject^ temp = CurrentScene->Find(static_cast<thomas::object::GameObject*>(old_native));
+		//		GameObject^ temp = CurrentScene->Find(static_cast<thomas::object::GameObject*>(old_native));
 
-				if (temp) // If temp is nullptr, no managed object has been invalidated.
-					temp->nativePtr = new_temp; // Nothing becomes invalidated if we don't do anything.
-			}
+		//		if (temp) // If temp is nullptr, no managed object has been invalidated.
+		//			temp->nativePtr = new_temp; // Nothing becomes invalidated if we don't do anything.
+		//	}
 
-		}
+		//}
 #endif
 	}
 	

--- a/thomas/ThomasEngine/src/object/GameObject.cpp
+++ b/thomas/ThomasEngine/src/object/GameObject.cpp
@@ -22,8 +22,8 @@ using namespace System;
 using namespace System::Threading;
 namespace ThomasEngine {
 
-	GameObject::GameObject() :
-		Object(thomas::ObjectHandler::Instance().createNewGameObject("gameobject"))
+	GameObject::GameObject() : 
+		Object(new thomas::object::GameObject("gameobject"))
 	{
 		m_name = "gameobject";
 #ifdef _EDITOR
@@ -33,7 +33,7 @@ namespace ThomasEngine {
 	}
 
 	GameObject::GameObject(String^ name) : 
-		Object(thomas::ObjectHandler::Instance().createNewGameObject(Utility::ConvertString(name)))
+		Object(new thomas::object::GameObject(Utility::ConvertString(name)))
 	{
 		m_name = name;
 		Tag = "";

--- a/thomas/ThomasEngine/src/object/Object.cpp
+++ b/thomas/ThomasEngine/src/object/Object.cpp
@@ -28,8 +28,8 @@ namespace ThomasEngine
 #endif
 		nativePtr->Destroy();
 	
-		if(this->GetType() != GameObject::typeid)
-			delete nativePtr;
+		//if(this->GetType() != GameObject::typeid)
+		delete nativePtr;
 	}
 	
 	void Object::Destroy()


### PR DESCRIPTION
As title;

How to test:

Crashes related to creation and deletion of gameobjects. Create and delete gameobjects and reload scenes.

Could degrade performance, since objects are now spread in memory