### PR TITLE
Menu/host menu

### DIFF
--- a/Concussion Ball/Assets/Scripts/Camera/GUI/GUIHostMenu.cs
+++ b/Concussion Ball/Assets/Scripts/Camera/GUI/GUIHostMenu.cs
@@ -728,9 +728,10 @@ public class GUIHostMenu : ScriptComponent
             HostBtn.color = Selected;
             if (HostBtn.Clicked())
             {
-                if (NotSimilarColor && NotSameName)
+                if (NotSimilarColor && NotSameName && Team1.text != "" && Team2.text != "")
                 {
                     DontTakeInput();
+                    AdjustMaxPlayers();
 
                     CameraMaster.instance.State = CAM_STATE.SELECT_TEAM;
                     //Set match options

--- a/Concussion Ball/Assets/Scripts/Camera/GUI/GUIHostMenu.cs
+++ b/Concussion Ball/Assets/Scripts/Camera/GUI/GUIHostMenu.cs
@@ -740,7 +740,6 @@ public class GUIHostMenu : ScriptComponent
                     MatchSystem.instance.MaxPlayers = ConvertToInt(MaxPlayersString.text);
                     MatchSystem.instance.MatchLength = ConvertToInt(TimeRoundString.text) * 60; //Convert to seconds.
                     MatchSystem.instance.ScoreLimit = ConvertToInt(ScoreLimitString.text);
-                    MatchSystem.instance.MaxPlayers = ConvertToInt(MaxPlayersString.text);
                     MatchSystem.instance.ServerName = ServerNameString.text;
                     MatchSystem.instance.PublicServer = PublicServerCheck.scale != Vector2.Zero ? true : false;
                     MatchSystem.instance.SpawnPowerupsDuringGame = PowerUpsCheck.scale != Vector2.Zero ? true : false;
@@ -875,6 +874,11 @@ public class GUIHostMenu : ScriptComponent
     private void AdjustMaxPlayers()
     {
         if (!InputMaxPlayers)
-            MaxPlayersString.text = (ConvertToInt(MaxPlayersString.text) + ConvertToInt(MaxPlayersString.text) % 2).ToString();
+        {
+            if (ConvertToInt(MaxPlayersString.text) <= 1)
+                MaxPlayersString.text = 2.ToString();
+            else
+                MaxPlayersString.text = (ConvertToInt(MaxPlayersString.text) + ConvertToInt(MaxPlayersString.text) % 2).ToString();
+        }
     }
 }

--- a/thomas/ThomasNet/NetworkManager.cs
+++ b/thomas/ThomasNet/NetworkManager.cs
@@ -97,8 +97,6 @@ namespace ThomasEngine.Network
             Listener.PeerConnectedEvent += Listener_PeerConnectedEvent;
             Listener.PeerDisconnectedEvent += Listener_PeerDisconnectedEvent;
             Listener.NetworkErrorEvent += Listener_NetworkErrorEvent;
-            
-            Scene.InitPlayerPool(PlayerPrefab, MaxPlayers);
         }
         
         private void NatPunchListener_NatIntroductionSuccess(System.Net.IPEndPoint targetEndPoint, string token)
@@ -124,7 +122,7 @@ namespace ThomasEngine.Network
             NetManager.Start(LocalPort);
             Debug.Log("NetManager started on port" + ":" + NetManager.LocalPort);
             LocalPeer = new NetPeer(NetManager, null);
-
+            Scene.InitPlayerPool(PlayerPrefab, MaxPlayers);
         }
 
         public void Host()


### PR DESCRIPTION
Host menu is more redundant.
Can't set 0 players or uneven amount.
Max players determines the pool of Chads that are created when the game is started.

Test:
- Try setting 0 players in HostMenu and then click outside the textbox. It will increase to 2.
- Try setting 0 players in HostMenu and without clicking outside the textbox before clicking Host Game.
- In SelectTeam menu it will indicate that it can only be 1 player in each team.
- Check in editor and you can see that there is only 3 Chads.  (One extra is created)