### PR TITLE
Fixed all(?) native heaps leaks, memory sits stable at 128 mb

### DIFF
--- a/thomas/ThomasCore/src/thomas/EditorWindow.cpp
+++ b/thomas/ThomasCore/src/thomas/EditorWindow.cpp
@@ -117,7 +117,7 @@ namespace thomas
 		{
 			for (int i = 0; i < m_guiData->CmdListsCount; ++i)
 				delete m_guiData->CmdLists[i];
-
+			delete[] m_guiData->CmdLists;
 			m_guiData->Clear();
 			delete m_guiData;
 			m_guiData = nullptr;

--- a/thomas/ThomasCore/src/thomas/utils/ProfileManager.h
+++ b/thomas/ThomasCore/src/thomas/utils/ProfileManager.h
@@ -9,7 +9,7 @@
 #include "..\..\..\include\nlohmann\json.hpp"
 #include "..\utils\atomic\Synchronization.h"
 #define BENCHMARK
-
+#undef BENCHMARK
 
 namespace thomas
 {

--- a/thomas/ThomasEngine/src/ThomasManaged.cpp
+++ b/thomas/ThomasEngine/src/ThomasManaged.cpp
@@ -162,12 +162,13 @@ namespace ThomasEngine {
 			UpdateFinished->Reset();
 			ThomasCore::Render();
 			RenderFinished->Set();
+#ifdef BENCHMARK
 			renderTime = ThomasTime::GetElapsedTime() - timeStart;
 
 			float gpuTime = utils::profiling::GpuProfiler::Instance()->GetFrameTime() * 1000.0f * 1000.0f * 1000.0f;
 			utils::profiling::ProfileManager::storeGpuSample((long long)gpuTime);
 
-#ifdef BENCHMARK
+
 			utils::profiling::ProfileManager::newFrame();
 #endif
 		}

--- a/thomas/ThomasNet/NetworkManager.cs
+++ b/thomas/ThomasNet/NetworkManager.cs
@@ -300,13 +300,11 @@ namespace ThomasEngine.Network
         { 
             if (NetManager.IsRunning)
             {
-                EngineAutoProfiler profile = new EngineAutoProfiler("NetworkManager Update");
                 NetManager.UpdateTime = (1000 / TICK_RATE);
                 if (NetManager.NatPunchEnabled)
                     NetManager.NatPunchModule.PollEvents();
                 NetManager.PollEvents();
                 Diagnostics();
-                profile.sendSample();
 
 
                 //Check real owners.


### PR DESCRIPTION
Fixed memory leaks related to imgui and profiling. 

Application will still increase in size during runtime, but this increase in size is normal allocation, which are taken care of during garbage collection.

How to test; 

Application does not crash, and native heap does not increase in size.

How to fail;

Crashes and increase in size of native heap that is not handled by GC.
